### PR TITLE
Add all the Thoth team members to the list of approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,18 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - goern
+  - codificat
   - fridex
-reviewers:
-  - pacospace
+  - goern
   - harshad16
   - kpostoffice
+  - mayaCostantini
+  - pacospace
+reviewers:
+  - codificat
+  - fridex
+  - goern
+  - harshad16
+  - kpostoffice
+  - mayaCostantini
+  - pacospace


### PR DESCRIPTION
## Related Issues and Dependencies

Suggested after thoth-station/prescriptions#18517

There are other PRs updating existing repos.

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Description

This is to add all the current members of the Thoth team as approvers, so that future projects inherit that list and everyone in the team is in a position to /approve changes to the repos.

I also added myself as a default reviewer. I am not sure if we should change the list of reviewers, or even have a default one. But I'm happy to receive requests to review new PRs (that I can redirect :smiley:)

Side note: sorting the list alphabetically.