### PR TITLE
Make GitHub issue templates a bit more friendly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,22 +3,25 @@ name: Bug report
 about: Create a report to help us improve
 labels: "kind/bug, needs-triage"
 ---
+## Bug description
+<!-- A clear and concise description of what the bug is. -->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
+### Steps to Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Actual behavior
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Additional context**
-Add any other context about the problem here.
+### Environment information
+<!-- Please include names and versions of the components involved.
+If appropriate, include relevant parts of their configuration. -->
+
+### Additional context
+<!-- Add any additional context information about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,24 +3,29 @@ name: Feature request
 about: Suggest an idea for this project
 labels: "kind/feature, needs-triage"
 ---
+## Problem statement
+<!-- Is your feature request related to a problem? Please provide a clear and concise description of what the problem is.
+Ex. I'm always frustrated when [...]
+This should be a user story! -->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-This should be a user story!
+## High-level Goals
+<!-- list of high-level Acceptance Criteria/Goals (that is signed off by the team, and unchangeable) -->
 
-**High-level Goals**
-list of high-level Acceptance Criteria/Goals (that is signed off by the team, and unchangeable)
+## Proposal description
+<!-- Describe the solution you'd like.
+A clear and concise description of what you want to happen. -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+### Alternatives
+<!-- Describe alternatives you've considered.
+A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Acceptance Criteria
+<!-- checklist of detailed Acceptance Criteria (that might extend over the lifetime of the card).
+Use checkboxes to track each item. -->
 
-**Acceptance Criteria**
-checklist of detailed Acceptance Criteria (that might extend over the lifetime of the card)
+- [ ] example
 
 <!-- If applicable add a measure of complexity (story points)/time estimate to the title using [...pt] -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,18 @@
 ## Related Issues and Dependencies
-
-…
+<!-- Mention any relevant issue/PR here.
+In particular, if this PR resolves issue XYZ, make sure you add a line:
+Fixes: #XYZ -->
 
 ## This introduces a breaking change
+<!-- Leave one of the options -->
 
-- [ ] Yes
-- [ ] No
+- Yes
+- No
 
 <!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
 
 ## This Pull Request implements
+<!-- Provide a summary of your changes here. -->
 
-… Explain your changes.
-
-## Description
-
-<!--- Describe your changes in detail -->
+### Description
+<!--- Describe your changes in detail here. -->


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
<!-- Provide a summary of your changes. -->

Some formatting changes to the GitHub templates for bug/feature issue and PR, aiming at improved usability.

### Description
<!--- Describe your changes in detail -->

I was finding myself editing a bit too much of the templates when creating an issue or PR. This is an attempt to make them more friendly.

Suggestions that are included:
- Use markdown structure elements (heading levels, with `##`) instead of just bold faces.
- Use that structure to nest some of the headings
- Put all the guidance text inside HTML comments, so that it does not have to be deleted manually every time
- Remove checkbox-based yes/no, as GitHub interprets this as a list of tasks to complete
- Some restructure and text changes, especially in the bug report template